### PR TITLE
UX: optionally hide topic list, additional styling

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -7,19 +7,13 @@
 
   &__images {
     display: grid;
-    grid-template-columns: repeat(
-      auto-fit,
-      minmax(calc(25% - var(--grid-gap)), 1fr)
-    );
+    grid-template-columns: repeat(auto-fit, calc(25% - var(--grid-gap)));
     gap: var(--grid-gap);
     @media screen and (max-width: 600px) {
       grid-template-columns: repeat(
         auto-fit,
         minmax(calc(50% - var(--grid-gap)), 1fr)
       );
-    }
-    @media screen and (max-width: 450px) {
-      grid-template-columns: repeat(auto-fit, 100%);
     }
   }
 
@@ -34,7 +28,8 @@
     min-width: 0;
     word-break: break-word;
     font-weight: normal;
-    margin-top: 0.25em;
+    padding-top: 0.25em;
+    margin-top: auto;
     padding: calc(var(--grid-gap) / 4) calc(var(--grid-gap) / 2);
     @media screen and (max-width: 600px) {
       font-size: var(--font-0);
@@ -52,11 +47,19 @@
     line-height: 1.2;
     box-shadow: shadow("dropdown");
     transition: box-shadow 0.25s;
+    display: flex;
+    flex-direction: column;
 
     &:focus,
     &:hover {
       box-shadow: shadow("card");
       text-decoration: underline;
     }
+  }
+}
+
+.category-featured-images--hide-topic-list-page {
+  #list-area {
+    display: none;
   }
 }

--- a/javascripts/discourse/components/category-featured-images.js
+++ b/javascripts/discourse/components/category-featured-images.js
@@ -7,8 +7,6 @@ export default class CategoryFeaturedImages extends Component {
   @controller application;
 
   get shouldShow() {
-    // we hide the topic list, so need to force the footer to show
-    this.application.showFooter = true;
     return this.router.currentRoute.name.includes("discovery.category");
   }
 
@@ -17,6 +15,11 @@ export default class CategoryFeaturedImages extends Component {
       .split("|")
       .map((id) => parseInt(id, 10));
     let currentCategoryID = this?.args?.category?.id;
+
+    if (categoryIDs?.includes(currentCategoryID)) {
+      // if we hide the topic list, we need to force the footer to show
+      this.application.showFooter = true;
+    }
 
     return categoryIDs.includes(currentCategoryID);
   }

--- a/javascripts/discourse/components/category-featured-images.js
+++ b/javascripts/discourse/components/category-featured-images.js
@@ -1,11 +1,24 @@
 import Component from "@glimmer/component";
 import { inject as service } from "@ember/service";
+import { inject as controller } from "@ember/controller";
 
 export default class CategoryFeaturedImages extends Component {
   @service router;
+  @controller application;
 
   get shouldShow() {
+    // we hide the topic list, so need to force the footer to show
+    this.application.showFooter = true;
     return this.router.currentRoute.name.includes("discovery.category");
+  }
+
+  get hideTopicList() {
+    let categoryIDs = settings.hide_topic_list
+      .split("|")
+      .map((id) => parseInt(id, 10));
+    let currentCategoryID = this?.args?.category?.id;
+
+    return categoryIDs.includes(currentCategoryID);
   }
 
   get filteredSetting() {
@@ -17,6 +30,10 @@ export default class CategoryFeaturedImages extends Component {
       if (Object.keys(filter).length) {
         filteredSetting.push(filter);
       }
+    });
+
+    filteredSetting.forEach((filter) => {
+      filter.slug = filter.section_title.toLowerCase().replace(/\s/g, "");
     });
 
     let currentCategoryID = this?.args?.category?.id;

--- a/javascripts/discourse/templates/components/category-featured-images.hbs
+++ b/javascripts/discourse/templates/components/category-featured-images.hbs
@@ -1,6 +1,10 @@
 {{#if shouldShow}}
+  <DSection
+    @pageClass={{if hideTopicList "category-featured-images--hide-topic-list"}}
+  />
+
   {{#each filteredSetting as |fs|}}
-    <div class="category-featured-image-section">
+    <div class="category-featured-image-section custom-filter_{{fs.slug}}">
       {{#if fs.section_title}}
         <h2
           class="category-featured-image-section__title"

--- a/settings.yml
+++ b/settings.yml
@@ -5,3 +5,8 @@ category_image_sections:
 
 max_image_height:
   default: "200px"
+
+hide_topic_list:
+  default: ""
+  type: list
+  description: "Hides the topic list using the category ID (the number found in the category page's URL)"


### PR DESCRIPTION
Customer requested these updates, they adjust the grid behavior a little and add the ability to hide the default topic list in desired categories. 